### PR TITLE
Add MySQL schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ DB_PASS=<passwort>
 DB_NAME=<datenbank>
 JWT_SECRET=<geheimnis>
 ```
+
+## Datenbankschema
+
+Die Datei `schema.sql` erstellt die benötigten Tabellen. Sie kann zum Beispiel mit folgendem Befehl ausgeführt werden:
+
+```bash
+mysql -u <benutzer> -p <datenbank> < schema.sql
+```

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,11 @@
+-- MySQL schema for Mensa-App
+-- Contains table definitions required by the API endpoints.
+
+CREATE TABLE IF NOT EXISTS `users` (
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `name` VARCHAR(255) NOT NULL,
+  `email` VARCHAR(255) NOT NULL UNIQUE,
+  `password` VARCHAR(255) NOT NULL,
+  `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- document how to create the DB table
- add `schema.sql` for the `users` table

## Testing
- `npm install`
- `npm run lint` *(fails: asks "How would you like to configure ESLint?")*


------
https://chatgpt.com/codex/tasks/task_e_68498840d3fc8325b170865cc3362add