### PR TITLE
Add basic login and register pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Dieses Projekt beinhaltet einfache API-Endpunkte für die Registrierung und Anme
 - **GET /api/protected**
   - Beispiel für eine geschützte Route, die ein gültiges JWT erwartet
 
+## Frontend
+
+Es stehen einfache Seiten unter `/login` und `/register` bereit. Die Formulare
+auf diesen Seiten senden Daten an die entsprechenden API-Endpunkte und speichern
+das erhaltene JWT bei Erfolg im `localStorage`.
+
 ## Konfiguration
 
 Die Datenbankverbindung und das JWT-Geheimnis werden über folgende Umgebungsvariablen konfiguriert:

--- a/app/login/page.js
+++ b/app/login/page.js
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Login fehlgeschlagen');
+        return;
+      }
+      localStorage.setItem('token', data.token);
+      router.push('/');
+    } catch {
+      setError('Login fehlgeschlagen');
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4">
+      <div className="w-full max-w-md space-y-6">
+        <h1 className="text-center text-2xl font-bold text-gray-900">Anmelden</h1>
+        {error && <p className="text-center text-red-600">{error}</p>}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            placeholder="E-Mail-Adresse"
+            className="w-full border p-2 rounded"
+          />
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            placeholder="Passwort"
+            className="w-full border p-2 rounded"
+          />
+          <button
+            type="submit"
+            className="w-full bg-indigo-600 text-white py-2 rounded hover:bg-indigo-700"
+          >
+            Anmelden
+          </button>
+        </form>
+        <p className="text-center text-sm">
+          Noch keinen Account?{' '}
+          <Link href="/register" className="text-indigo-600 hover:underline">
+            Registrieren
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/register/page.js
+++ b/app/register/page.js
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+export default function RegisterPage() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch('/api/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, password }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Registrierung fehlgeschlagen');
+        return;
+      }
+      localStorage.setItem('token', data.token);
+      router.push('/');
+    } catch {
+      setError('Registrierung fehlgeschlagen');
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4">
+      <div className="w-full max-w-md space-y-6">
+        <h1 className="text-center text-2xl font-bold text-gray-900">Registrieren</h1>
+        {error && <p className="text-center text-red-600">{error}</p>}
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            placeholder="Name"
+            className="w-full border p-2 rounded"
+          />
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            placeholder="E-Mail-Adresse"
+            className="w-full border p-2 rounded"
+          />
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            placeholder="Passwort"
+            className="w-full border p-2 rounded"
+          />
+          <button
+            type="submit"
+            className="w-full bg-indigo-600 text-white py-2 rounded hover:bg-indigo-700"
+          >
+            Registrieren
+          </button>
+        </form>
+        <p className="text-center text-sm">
+          Bereits registriert?{' '}
+          <Link href="/login" className="text-indigo-600 hover:underline">
+            Anmelden
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- document availability of login/register frontend
- add `/login` and `/register` pages using Next.js

## Testing
- `CI=true npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6849c381412083258a33e2c954cd5173