### PR TITLE
Implement daily menus and error message updates

### DIFF
--- a/app/api/order/route.js
+++ b/app/api/order/route.js
@@ -25,7 +25,7 @@ export async function POST(req) {
   if (day) {
     const weekday = new Date(date).toLocaleDateString('de-DE', { weekday: 'long' }).toLowerCase();
     if (weekday !== day.toLowerCase()) {
-      return NextResponse.json({ error: 'Gericht für diesen Tag nicht verfügbar' }, { status: 400 });
+      return NextResponse.json({ error: 'Gericht an diesem Tag nicht verfügbar' }, { status: 400 });
     }
   }
 

--- a/app/page.js
+++ b/app/page.js
@@ -3,35 +3,132 @@
 import { useState } from 'react';
 import PreorderModal from '../components/PreorderModal';
 
-const menuItems = [
-  {
-    title: 'Hähnchen-Gemüsepfanne mit Reis',
-    image: '/reis_haehnchen_pfanne_2.jpg',
-    studentPrice: '10.00',
-    teacherPrice: '12.00',
-    day: 'montag'
-  },
-  {
-    title: 'Spaghetti mit Hackfleisch-Tomatensauce',
-    image: '/202_spaghetti-bolognese.jpg',
-    studentPrice: '10.00',
-    teacherPrice: '12.00',
-    day: 'montag'
-  },
-  {
-    title: 'Gemüse-Lasagne mit Spinat und Ricotta',
-    image: '/Download.jpg',
-    studentPrice: '10.00',
-    teacherPrice: '12.00',
-    day: 'montag'
-  }
-];
+const menus = {
+  montag: [
+    {
+      title: 'Hähnchen-Gemüsepfanne mit Reis',
+      image: '/reis_haehnchen_pfanne_2.jpg',
+      studentPrice: '10.00',
+      teacherPrice: '12.00',
+      day: 'montag'
+    },
+    {
+      title: 'Spaghetti mit Hackfleisch-Tomatensauce',
+      image: '/202_spaghetti-bolognese.jpg',
+      studentPrice: '10.00',
+      teacherPrice: '12.00',
+      day: 'montag'
+    },
+    {
+      title: 'Gemüse-Lasagne mit Spinat und Ricotta',
+      image: '/Download.jpg',
+      studentPrice: '10.00',
+      teacherPrice: '12.00',
+      day: 'montag'
+    }
+  ],
+  dienstag: [
+    {
+      title: 'Rindergeschnetzeltes mit Reis',
+      image: '/reis_haehnchen_pfanne_2.jpg',
+      studentPrice: '10.00',
+      teacherPrice: '12.00',
+      day: 'dienstag'
+    },
+    {
+      title: 'Penne Arrabiata',
+      image: '/202_spaghetti-bolognese.jpg',
+      studentPrice: '10.00',
+      teacherPrice: '12.00',
+      day: 'dienstag'
+    },
+    {
+      title: 'Gemüse-Curry',
+      image: '/Download.jpg',
+      studentPrice: '10.00',
+      teacherPrice: '12.00',
+      day: 'dienstag'
+    }
+  ],
+  mittwoch: [
+    {
+      title: 'Fischstäbchen mit Kartoffelsalat',
+      image: '/reis_haehnchen_pfanne_2.jpg',
+      studentPrice: '10.00',
+      teacherPrice: '12.00',
+      day: 'mittwoch'
+    },
+    {
+      title: 'Käsespätzle',
+      image: '/202_spaghetti-bolognese.jpg',
+      studentPrice: '10.00',
+      teacherPrice: '12.00',
+      day: 'mittwoch'
+    },
+    {
+      title: 'Tomaten-Mozzarella-Auflauf',
+      image: '/Download.jpg',
+      studentPrice: '10.00',
+      teacherPrice: '12.00',
+      day: 'mittwoch'
+    }
+  ],
+  donnerstag: [
+    {
+      title: 'Schweinebraten mit Knödel',
+      image: '/reis_haehnchen_pfanne_2.jpg',
+      studentPrice: '10.00',
+      teacherPrice: '12.00',
+      day: 'donnerstag'
+    },
+    {
+      title: 'Nudelauflauf',
+      image: '/202_spaghetti-bolognese.jpg',
+      studentPrice: '10.00',
+      teacherPrice: '12.00',
+      day: 'donnerstag'
+    },
+    {
+      title: 'Grüne Bohnen Eintopf',
+      image: '/Download.jpg',
+      studentPrice: '10.00',
+      teacherPrice: '12.00',
+      day: 'donnerstag'
+    }
+  ],
+  freitag: [
+    {
+      title: 'Currywurst mit Pommes',
+      image: '/reis_haehnchen_pfanne_2.jpg',
+      studentPrice: '10.00',
+      teacherPrice: '12.00',
+      day: 'freitag'
+    },
+    {
+      title: 'Pizza Margherita',
+      image: '/202_spaghetti-bolognese.jpg',
+      studentPrice: '10.00',
+      teacherPrice: '12.00',
+      day: 'freitag'
+    },
+    {
+      title: 'Linsensuppe',
+      image: '/Download.jpg',
+      studentPrice: '10.00',
+      teacherPrice: '12.00',
+      day: 'freitag'
+    }
+  ]
+};
 
 const weekDays = ['Mo', 'Di', 'Mi', 'Do', 'Fr'];
+const dayKeys = ['montag', 'dienstag', 'mittwoch', 'donnerstag', 'freitag'];
 
 export default function Home() {
   const [currentDay, setCurrentDay] = useState(0);
   const [selectedMeal, setSelectedMeal] = useState(null);
+  const currentDayKey = dayKeys[currentDay];
+  const menuItems = menus[currentDayKey];
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -39,7 +136,7 @@ export default function Home() {
       {/* Main Content */}
       <main className="container mx-auto px-6 pt-8 pb-24">
         <div className="max-w-4xl mx-auto bg-[#fdf1cc] rounded-3xl p-8 shadow-lg">
-          <h1 className="text-4xl font-bold text-center mb-3 text-gray-800">Menu-Montag</h1>
+          <h1 className="text-4xl font-bold text-center mb-3 text-gray-800">{`Menu-${currentDayKey.charAt(0).toUpperCase() + currentDayKey.slice(1)}`}</h1>
           <h2 className="text-2xl font-semibold text-center mb-12 text-gray-700">Hauptgang</h2>
 
           <div className="space-y-10">
@@ -92,7 +189,7 @@ export default function Home() {
         <div className="container mx-auto px-6 py-4">
           <div className="flex items-center justify-between max-w-2xl mx-auto">
             <button
-              onClick={() => setCurrentDay((prev) => (prev > 0 ? prev - 1 : 6))}
+              onClick={() => setCurrentDay((prev) => (prev > 0 ? prev - 1 : dayKeys.length - 1))}
               className="text-3xl text-gray-600 hover:text-gray-800 transition-colors p-2 hover:bg-gray-100 rounded-full"
             >
               ←
@@ -115,7 +212,7 @@ export default function Home() {
             </div>
 
             <button
-              onClick={() => setCurrentDay((prev) => (prev < 6 ? prev + 1 : 0))}
+              onClick={() => setCurrentDay((prev) => (prev < dayKeys.length - 1 ? prev + 1 : 0))}
               className="text-3xl text-gray-600 hover:text-gray-800 transition-colors p-2 hover:bg-gray-100 rounded-full"
             >
               →

--- a/components/PreorderModal.js
+++ b/components/PreorderModal.js
@@ -30,7 +30,7 @@ export default function PreorderModal({ meal, isOpen, onClose }) {
         .toLocaleDateString('de-DE', { weekday: 'long' })
         .toLowerCase();
       if (weekday !== meal.day.toLowerCase()) {
-        setMessage('Dieses Gericht ist an diesem Tag nicht verfügbar');
+        setMessage('Gericht an diesem Tag nicht verfügbar');
         return;
       }
     }
@@ -75,7 +75,17 @@ export default function PreorderModal({ meal, isOpen, onClose }) {
           onChange={e => setTime(e.target.value)}
           className="w-full border p-2 rounded"
         />
-        {message && <p className="text-center text-sm text-green-600">{message}</p>}
+        {message && (
+          <p
+            className={`text-center text-sm ${
+              message.toLowerCase().includes('erfolgreich')
+                ? 'text-green-600'
+                : 'text-red-600'
+            }`}
+          >
+            {message}
+          </p>
+        )}
         <div className="flex justify-end space-x-2">
           <button onClick={onClose} className="px-4 py-2 rounded bg-gray-200">Abbrechen</button>
           <button onClick={handleOrder} className="px-4 py-2 rounded bg-indigo-600 text-white">Bestellen</button>


### PR DESCRIPTION
## Summary
- create distinct menus for each weekday and add day navigation
- adapt PreorderModal to show error messages in red
- adjust error text for invalid day orders

## Testing
- `npm run lint` *(fails: `next lint` not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_684ab5ec87b083258e03285f5f014381