### PR TITLE
Improve app styling for modern look

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,10 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
-@tailwind utilities; 
+@tailwind utilities;
+
+body {
+  @apply font-sans bg-gray-50 text-gray-800;
+  font-family: 'Inter', sans-serif;
+}

--- a/app/login/page.js
+++ b/app/login/page.js
@@ -34,9 +34,9 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4">
-      <div className="w-full max-w-md space-y-6">
-        <h1 className="text-center text-2xl font-bold text-gray-900">Anmelden</h1>
+    <div className="min-h-screen flex items-center justify-center p-4 bg-gray-100">
+      <div className="w-full max-w-md bg-white rounded-xl shadow-lg p-8 space-y-6">
+        <h1 className="text-center text-2xl font-bold">Anmelden</h1>
         {error && <p className="text-center text-red-600">{error}</p>}
         <form onSubmit={handleSubmit} className="space-y-4">
           <input
@@ -45,7 +45,7 @@ export default function LoginPage() {
             onChange={(e) => setEmail(e.target.value)}
             required
             placeholder="E-Mail-Adresse"
-            className="w-full border p-2 rounded"
+            className="w-full border border-gray-300 p-2 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
           <input
             type="password"
@@ -53,11 +53,11 @@ export default function LoginPage() {
             onChange={(e) => setPassword(e.target.value)}
             required
             placeholder="Passwort"
-            className="w-full border p-2 rounded"
+            className="w-full border border-gray-300 p-2 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
           <button
             type="submit"
-            className="w-full bg-indigo-600 text-white py-2 rounded hover:bg-indigo-700"
+            className="w-full bg-indigo-600 text-white py-2 rounded hover:bg-indigo-700 transition-colors"
           >
             Anmelden
           </button>

--- a/app/page.js
+++ b/app/page.js
@@ -139,10 +139,10 @@ export default function Home() {
           <h1 className="text-4xl font-bold text-center mb-3 text-gray-800">{`Menu-${currentDayKey.charAt(0).toUpperCase() + currentDayKey.slice(1)}`}</h1>
           <h2 className="text-2xl font-semibold text-center mb-12 text-gray-700">Hauptgang</h2>
 
-          <div className="space-y-10">
+          <div className="grid gap-10 sm:grid-cols-2">
             {menuItems.map((item, index) => (
-              <div 
-                key={index} 
+              <div
+                key={index}
                 className="bg-white rounded-2xl p-8 shadow-md hover:shadow-lg transition-shadow"
               >
                 <div className="flex flex-col md:flex-row items-center gap-8">
@@ -173,7 +173,6 @@ export default function Home() {
                   </div>
                 </div>
               </div>
-            </div>
             ))}
           </div>
         </div>

--- a/app/register/page.js
+++ b/app/register/page.js
@@ -33,9 +33,9 @@ export default function RegisterPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4">
-      <div className="w-full max-w-md space-y-6">
-        <h1 className="text-center text-2xl font-bold text-gray-900">Registrieren</h1>
+    <div className="min-h-screen flex items-center justify-center p-4 bg-gray-100">
+      <div className="w-full max-w-md bg-white rounded-xl shadow-lg p-8 space-y-6">
+        <h1 className="text-center text-2xl font-bold">Registrieren</h1>
         {error && <p className="text-center text-red-600">{error}</p>}
         <form onSubmit={handleSubmit} className="space-y-4">
           <input
@@ -44,7 +44,7 @@ export default function RegisterPage() {
             onChange={(e) => setName(e.target.value)}
             required
             placeholder="Name"
-            className="w-full border p-2 rounded"
+            className="w-full border border-gray-300 p-2 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
           <input
             type="email"
@@ -52,7 +52,7 @@ export default function RegisterPage() {
             onChange={(e) => setEmail(e.target.value)}
             required
             placeholder="E-Mail-Adresse"
-            className="w-full border p-2 rounded"
+            className="w-full border border-gray-300 p-2 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
           <input
             type="password"
@@ -60,11 +60,11 @@ export default function RegisterPage() {
             onChange={(e) => setPassword(e.target.value)}
             required
             placeholder="Passwort"
-            className="w-full border p-2 rounded"
+            className="w-full border border-gray-300 p-2 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
           <button
             type="submit"
-            className="w-full bg-indigo-600 text-white py-2 rounded hover:bg-indigo-700"
+            className="w-full bg-indigo-600 text-white py-2 rounded hover:bg-indigo-700 transition-colors"
           >
             Registrieren
           </button>

--- a/components/Header.js
+++ b/components/Header.js
@@ -13,7 +13,7 @@ export default function Header() {
   };
 
   return (
-    <header className="fixed top-0 left-0 right-0 bg-white shadow-sm z-10">
+    <header className="fixed top-0 left-0 right-0 bg-white/70 backdrop-blur-md shadow-sm z-10">
       <div className="container mx-auto px-6 py-4 flex justify-between items-center">
         <Link href="/" className="text-2xl font-bold text-gray-800 hover:text-gray-600 transition-colors">
           Mensa-BZZ

--- a/components/PreorderModal.js
+++ b/components/PreorderModal.js
@@ -58,14 +58,20 @@ export default function PreorderModal({ meal, isOpen, onClose }) {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-20">
-      <div className="bg-white rounded-lg p-6 w-80 space-y-4">
-        <h3 className="text-lg font-semibold">{meal.title}</h3>
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-20 p-4">
+      <div className="bg-white rounded-xl shadow-lg p-6 w-full max-w-sm space-y-4 relative">
+        <button
+          onClick={onClose}
+          className="absolute top-3 right-3 text-gray-500 hover:text-gray-700"
+        >
+          ✕
+        </button>
+        <h3 className="text-lg font-semibold text-center">{meal.title}</h3>
         <input
           type="date"
           value={date}
           onChange={e => setDate(e.target.value)}
-          className="w-full border p-2 rounded"
+          className="w-full border border-gray-300 p-2 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
         />
         <input
           type="time"
@@ -73,7 +79,7 @@ export default function PreorderModal({ meal, isOpen, onClose }) {
           max="13:00"
           value={time}
           onChange={e => setTime(e.target.value)}
-          className="w-full border p-2 rounded"
+          className="w-full border border-gray-300 p-2 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
         />
         {message && (
           <p
@@ -86,9 +92,19 @@ export default function PreorderModal({ meal, isOpen, onClose }) {
             {message}
           </p>
         )}
-        <div className="flex justify-end space-x-2">
-          <button onClick={onClose} className="px-4 py-2 rounded bg-gray-200">Abbrechen</button>
-          <button onClick={handleOrder} className="px-4 py-2 rounded bg-indigo-600 text-white">Bestellen</button>
+        <div className="flex justify-end space-x-2 pt-2">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300 transition-colors"
+          >
+            Abbrechen
+          </button>
+          <button
+            onClick={handleOrder}
+            className="px-4 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
+          >
+            Bestellen
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- import Inter font and set global base styles
- redesign login and registration pages with a centered card layout
- enhance preorder modal with rounded card and close button
- add blurred background to header
- display menu items in a responsive grid

## Testing
- `npx next lint` *(fails: Need to install next)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab94fac288325a009ec9d94a41710