### PR TITLE
Allow editing default menus

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -7,138 +7,6 @@ import { useAuth } from '../context/AuthContext';
 const weekDays = ['Mo', 'Di', 'Mi', 'Do', 'Fr'];
 const dayKeys = ['montag', 'dienstag', 'mittwoch', 'donnerstag', 'freitag'];
 
-const defaultMenus = {
-  montag: [
-    {
-      id: 'default-montag-1',
-      title: 'H\xE4hnchen-Gem\xFCsepfanne mit Reis',
-      image: '/reis_haehnchen_pfanne_2.jpg',
-      student_price: '10.00',
-      teacher_price: '12.00',
-      day: 'montag',
-    },
-    {
-      id: 'default-montag-2',
-      title: 'Spaghetti mit Hackfleisch-Tomatensauce',
-      image: '/202_spaghetti-bolognese.jpg',
-      student_price: '10.00',
-      teacher_price: '12.00',
-      day: 'montag',
-    },
-    {
-      id: 'default-montag-3',
-      title: 'Gem\xFCse-Lasagne mit Spinat und Ricotta',
-      image: '/Download.jpg',
-      student_price: '10.00',
-      teacher_price: '12.00',
-      day: 'montag',
-    },
-  ],
-  dienstag: [
-    {
-      id: 'default-dienstag-1',
-      title: 'Rindergeschnetzeltes mit Reis',
-      image: '/reis_haehnchen_pfanne_2.jpg',
-      student_price: '10.00',
-      teacher_price: '12.00',
-      day: 'dienstag',
-    },
-    {
-      id: 'default-dienstag-2',
-      title: 'Penne Arrabiata',
-      image: '/202_spaghetti-bolognese.jpg',
-      student_price: '10.00',
-      teacher_price: '12.00',
-      day: 'dienstag',
-    },
-    {
-      id: 'default-dienstag-3',
-      title: 'Gem\xFCse-Curry',
-      image: '/Download.jpg',
-      student_price: '10.00',
-      teacher_price: '12.00',
-      day: 'dienstag',
-    },
-  ],
-  mittwoch: [
-    {
-      id: 'default-mittwoch-1',
-      title: 'Fischst\xE4bchen mit Kartoffelsalat',
-      image: '/reis_haehnchen_pfanne_2.jpg',
-      student_price: '10.00',
-      teacher_price: '12.00',
-      day: 'mittwoch',
-    },
-    {
-      id: 'default-mittwoch-2',
-      title: 'K\xE4sesp\xE4tzle',
-      image: '/202_spaghetti-bolognese.jpg',
-      student_price: '10.00',
-      teacher_price: '12.00',
-      day: 'mittwoch',
-    },
-    {
-      id: 'default-mittwoch-3',
-      title: 'Tomaten-Mozzarella-Auflauf',
-      image: '/Download.jpg',
-      student_price: '10.00',
-      teacher_price: '12.00',
-      day: 'mittwoch',
-    },
-  ],
-  donnerstag: [
-    {
-      id: 'default-donnerstag-1',
-      title: 'Schweinebraten mit Kn\xF6del',
-      image: '/reis_haehnchen_pfanne_2.jpg',
-      student_price: '10.00',
-      teacher_price: '12.00',
-      day: 'donnerstag',
-    },
-    {
-      id: 'default-donnerstag-2',
-      title: 'Nudelauflauf',
-      image: '/202_spaghetti-bolognese.jpg',
-      student_price: '10.00',
-      teacher_price: '12.00',
-      day: 'donnerstag',
-    },
-    {
-      id: 'default-donnerstag-3',
-      title: 'Gr\xFCne Bohnen Eintopf',
-      image: '/Download.jpg',
-      student_price: '10.00',
-      teacher_price: '12.00',
-      day: 'donnerstag',
-    },
-  ],
-  freitag: [
-    {
-      id: 'default-freitag-1',
-      title: 'Currywurst mit Pommes',
-      image: '/reis_haehnchen_pfanne_2.jpg',
-      student_price: '10.00',
-      teacher_price: '12.00',
-      day: 'freitag',
-    },
-    {
-      id: 'default-freitag-2',
-      title: 'Pizza Margherita',
-      image: '/202_spaghetti-bolognese.jpg',
-      student_price: '10.00',
-      teacher_price: '12.00',
-      day: 'freitag',
-    },
-    {
-      id: 'default-freitag-3',
-      title: 'Linsensuppe',
-      image: '/Download.jpg',
-      student_price: '10.00',
-      teacher_price: '12.00',
-      day: 'freitag',
-    },
-  ],
-};
 
 export default function Home() {
   const [currentDay, setCurrentDay] = useState(0);
@@ -152,8 +20,7 @@ export default function Home() {
     const res = await fetch('/api/menus');
     const data = await res.json();
     const grouped = dayKeys.reduce((acc, key) => {
-      const fromDb = data.menus.filter(m => m.day === key);
-      acc[key] = [...defaultMenus[key], ...fromDb];
+      acc[key] = data.menus.filter(m => m.day === key);
       return acc;
     }, {});
     setMenus(grouped);

--- a/schema.sql
+++ b/schema.sql
@@ -30,3 +30,21 @@ CREATE TABLE IF NOT EXISTS `menus` (
   `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Seed default menus so they can be managed like normal entries
+INSERT INTO `menus` (`title`, `image`, `student_price`, `teacher_price`, `day`) VALUES
+('H\xE4hnchen-Gem\xFCsepfanne mit Reis', '/reis_haehnchen_pfanne_2.jpg', 10.00, 12.00, 'montag'),
+('Spaghetti mit Hackfleisch-Tomatensauce', '/202_spaghetti-bolognese.jpg', 10.00, 12.00, 'montag'),
+('Gem\xFCse-Lasagne mit Spinat und Ricotta', '/Download.jpg', 10.00, 12.00, 'montag'),
+('Rindergeschnetzeltes mit Reis', '/reis_haehnchen_pfanne_2.jpg', 10.00, 12.00, 'dienstag'),
+('Penne Arrabiata', '/202_spaghetti-bolognese.jpg', 10.00, 12.00, 'dienstag'),
+('Gem\xFCse-Curry', '/Download.jpg', 10.00, 12.00, 'dienstag'),
+('Fischst\xE4bchen mit Kartoffelsalat', '/reis_haehnchen_pfanne_2.jpg', 10.00, 12.00, 'mittwoch'),
+('K\xE4sesp\xE4tzle', '/202_spaghetti-bolognese.jpg', 10.00, 12.00, 'mittwoch'),
+('Tomaten-Mozzarella-Auflauf', '/Download.jpg', 10.00, 12.00, 'mittwoch'),
+('Schweinebraten mit Kn\xF6del', '/reis_haehnchen_pfanne_2.jpg', 10.00, 12.00, 'donnerstag'),
+('Nudelauflauf', '/202_spaghetti-bolognese.jpg', 10.00, 12.00, 'donnerstag'),
+('Gr\xFCne Bohnen Eintopf', '/Download.jpg', 10.00, 12.00, 'donnerstag'),
+('Currywurst mit Pommes', '/reis_haehnchen_pfanne_2.jpg', 10.00, 12.00, 'freitag'),
+('Pizza Margherita', '/202_spaghetti-bolognese.jpg', 10.00, 12.00, 'freitag'),
+('Linsensuppe', '/Download.jpg', 10.00, 12.00, 'freitag');


### PR DESCRIPTION
## Summary
- store default menu entries directly in `schema.sql`
- remove hardcoded fallback menus from the client and load everything from the DB

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6851d88eb9a08325af1f8be75c585930