### PR TITLE
Implement cart for multiple meal orders

### DIFF
--- a/app/cart/page.js
+++ b/app/cart/page.js
@@ -1,0 +1,86 @@
+'use client';
+
+import { useCart } from '../../context/CartContext';
+import { useState } from 'react';
+
+export default function CartPage() {
+  const { cartItems, removeItem, clearCart } = useCart();
+  const [message, setMessage] = useState('');
+
+  const handleCheckout = async () => {
+    setMessage('');
+    const token = localStorage.getItem('token');
+    if (!token) {
+      setMessage('Bitte zuerst anmelden');
+      return;
+    }
+    for (const item of cartItems) {
+      const res = await fetch('/api/order', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          mealName: item.mealName,
+          date: item.date,
+          time: item.time,
+          day: item.day,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setMessage(data.error || 'Fehler beim Bestellen');
+        return;
+      }
+    }
+    clearCart();
+    setMessage('Bestellung erfolgreich!');
+  };
+
+  return (
+    <div className="container mx-auto px-6 py-8">
+      <h1 className="text-3xl font-bold mb-6">Warenkorb</h1>
+      {cartItems.length === 0 ? (
+        <p>Ihr Warenkorb ist leer.</p>
+      ) : (
+        <>
+          <ul className="space-y-4 mb-6">
+            {cartItems.map((item, index) => (
+              <li
+                key={index}
+                className="p-4 bg-white shadow rounded flex justify-between items-center"
+              >
+                <div>
+                  <p className="font-semibold">{item.mealName}</p>
+                  <p className="text-sm text-gray-600">
+                    {item.date} {item.time}
+                  </p>
+                </div>
+                <button
+                  onClick={() => removeItem(index)}
+                  className="text-red-600 hover:underline"
+                >
+                  Entfernen
+                </button>
+              </li>
+            ))}
+          </ul>
+          {message && (
+            <p
+              className={`mb-4 ${message.includes('erfolgreich') ? 'text-green-600' : 'text-red-600'}`}
+            >
+              {message}
+            </p>
+          )}
+          <button
+            onClick={handleCheckout}
+            className="bg-primary text-white px-4 py-2 rounded"
+          >
+            Bestellung abschicken
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,6 +1,7 @@
 import './globals.css';
 import Header from '../components/Header';
 import { AuthProvider } from '../context/AuthContext';
+import { CartProvider } from '../context/CartContext';
 
 export const metadata = {
   title: 'Mensa-BZZ',
@@ -12,8 +13,10 @@ export default function RootLayout({ children }) {
     <html lang="de">
       <body className="bg-gray-50 text-gray-800 font-sans">
         <AuthProvider>
-          <Header />
-          <div className="pt-20">{children}</div>
+          <CartProvider>
+            <Header />
+            <div className="pt-20">{children}</div>
+          </CartProvider>
         </AuthProvider>
       </body>
     </html>

--- a/components/Header.js
+++ b/components/Header.js
@@ -2,10 +2,12 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '../context/AuthContext';
+import { useCart } from '../context/CartContext';
 
 export default function Header() {
   const router = useRouter();
   const { isAuthenticated, logout } = useAuth();
+  const { cartItems } = useCart();
 
   const handleLogout = () => {
     logout();
@@ -19,6 +21,9 @@ export default function Header() {
           Mensa-BZZ
         </Link>
         <div className="space-x-6">
+          <Link href="/cart" className="text-gray-600 hover:text-primary-dark font-medium transition-colors">
+            Warenkorb ({cartItems.length})
+          </Link>
           {isAuthenticated ? (
             <button onClick={handleLogout} className="text-gray-600 hover:text-gray-800 font-medium transition-colors">
               Logout

--- a/context/CartContext.js
+++ b/context/CartContext.js
@@ -1,0 +1,43 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState } from 'react';
+
+const CartContext = createContext();
+
+export function CartProvider({ children }) {
+  const [cartItems, setCartItems] = useState([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('cart');
+    if (stored) {
+      try {
+        setCartItems(JSON.parse(stored));
+      } catch {
+        setCartItems([]);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('cart', JSON.stringify(cartItems));
+  }, [cartItems]);
+
+  const addItem = (item) => setCartItems((items) => [...items, item]);
+
+  const removeItem = (index) =>
+    setCartItems((items) => items.filter((_, i) => i !== index));
+
+  const clearCart = () => setCartItems([]);
+
+  return (
+    <CartContext.Provider value={{ cartItems, addItem, removeItem, clearCart }}>
+      {children}
+    </CartContext.Provider>
+  );
+}
+
+export function useCart() {
+  const ctx = useContext(CartContext);
+  if (!ctx) throw new Error('useCart must be used within a CartProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add context for storing cart items
- show cart link with item count in header
- enable adding meals to cart from preorder modal
- provide cart page with checkout logic
- wrap layout with CartProvider

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851dbc59178832595c65ff8844d502e