### PR TITLE
Add menu info modal with allergens

### DIFF
--- a/app/api/menus/[id]/route.js
+++ b/app/api/menus/[id]/route.js
@@ -38,6 +38,8 @@ export async function PUT(req, { params }) {
   const teacherPrice = formData.get('teacherPrice');
   const day = formData.get('day');
   const file = formData.get('image');
+  const ingredients = formData.get('ingredients') || '';
+  const allergens = formData.get('allergens') || '';
 
   if (!title || !studentPrice || !teacherPrice || !day) {
     return NextResponse.json({ error: 'Alle Felder erforderlich' }, { status: 400 });
@@ -55,9 +57,9 @@ export async function PUT(req, { params }) {
   }
 
   try {
-    const fields = [title, studentPrice, teacherPrice, day];
+    const fields = [title, studentPrice, teacherPrice, day, ingredients, allergens];
     let query =
-      'UPDATE menus SET title=?, student_price=?, teacher_price=?, day=?';
+      'UPDATE menus SET title=?, student_price=?, teacher_price=?, day=?, ingredients=?, allergens=?';
     if (imagePath) {
       query += ', image=?';
       fields.push(imagePath);

--- a/app/api/menus/route.js
+++ b/app/api/menus/route.js
@@ -33,6 +33,8 @@ export async function POST(req) {
   const teacherPrice = formData.get('teacherPrice');
   const day = formData.get('day');
   const file = formData.get('image');
+  const ingredients = formData.get('ingredients') || '';
+  const allergens = formData.get('allergens') || '';
 
   if (!title || !studentPrice || !teacherPrice || !day || !file) {
     return NextResponse.json({ error: 'Alle Felder erforderlich' }, { status: 400 });
@@ -49,10 +51,10 @@ export async function POST(req) {
 
   try {
     const [result] = await pool.query(
-      'INSERT INTO menus (title, image, student_price, teacher_price, day) VALUES (?, ?, ?, ?, ?)',
-      [title, imagePath, studentPrice, teacherPrice, day]
+      'INSERT INTO menus (title, image, student_price, teacher_price, day, ingredients, allergens) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [title, imagePath, studentPrice, teacherPrice, day, ingredients, allergens]
     );
-    return NextResponse.json({ id: result.insertId, title, image: imagePath, student_price: studentPrice, teacher_price: teacherPrice, day });
+    return NextResponse.json({ id: result.insertId, title, image: imagePath, student_price: studentPrice, teacher_price: teacherPrice, day, ingredients, allergens });
   } catch (err) {
     console.error(err);
     return NextResponse.json({ error: 'Speichern fehlgeschlagen' }, { status: 500 });

--- a/app/page.js
+++ b/app/page.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import PreorderModal from '../components/PreorderModal';
+import InfoModal from '../components/InfoModal';
 import { useAuth } from '../context/AuthContext';
 
 const weekDays = ['Mo', 'Di', 'Mi', 'Do', 'Fr'];
@@ -11,6 +12,7 @@ const dayKeys = ['montag', 'dienstag', 'mittwoch', 'donnerstag', 'freitag'];
 export default function Home() {
   const [currentDay, setCurrentDay] = useState(0);
   const [selectedMeal, setSelectedMeal] = useState(null);
+  const [infoMeal, setInfoMeal] = useState(null);
   const [menus, setMenus] = useState({});
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState(null);
@@ -97,6 +99,13 @@ export default function Home() {
                       >
                         Vorbestellen
                       </button>
+                      <button
+                        onClick={() => setInfoMeal(item)}
+                        className="p-2 text-blue-600 hover:bg-gray-100 rounded-full"
+                        aria-label="Details"
+                      >
+                        i
+                      </button>
                       {user?.role === 'admin' && (
                         <>
                           <button
@@ -122,6 +131,7 @@ export default function Home() {
         </div>
       </main>
       <PreorderModal meal={selectedMeal || {}} isOpen={selectedMeal !== null} onClose={() => setSelectedMeal(null)} />
+      <InfoModal meal={infoMeal || {}} isOpen={infoMeal !== null} onClose={() => setInfoMeal(null)} />
       {showForm && <MealForm day={currentDayKey} meal={editing} onClose={() => setShowForm(false)} />}
       <footer className="fixed bottom-0 left-0 right-0 bg-white shadow-sm">
         <div className="container mx-auto px-6 py-4">
@@ -165,6 +175,8 @@ function MealForm({ day, meal, onClose }) {
   const [title, setTitle] = useState(meal?.title || '');
   const [studentPrice, setStudentPrice] = useState(meal?.student_price || '');
   const [teacherPrice, setTeacherPrice] = useState(meal?.teacher_price || '');
+  const [ingredients, setIngredients] = useState(meal?.ingredients || '');
+  const [allergens, setAllergens] = useState(meal?.allergens || '');
   const [image, setImage] = useState(null);
 
   const handleSubmit = async () => {
@@ -174,6 +186,8 @@ function MealForm({ day, meal, onClose }) {
     form.append('studentPrice', studentPrice);
     form.append('teacherPrice', teacherPrice);
     form.append('day', day);
+    form.append('ingredients', ingredients);
+    form.append('allergens', allergens);
     if (image) form.append('image', image);
 
     const res = await fetch(isEdit ? `/api/menus/${meal.id}` : '/api/menus', {
@@ -209,6 +223,19 @@ function MealForm({ day, meal, onClose }) {
           value={teacherPrice}
           onChange={e => setTeacherPrice(e.target.value)}
           placeholder="Preis Lehrer"
+          className="w-full border p-2 rounded"
+        />
+        <textarea
+          value={ingredients}
+          onChange={e => setIngredients(e.target.value)}
+          placeholder="Zutaten, kommasepariert"
+          className="w-full border p-2 rounded"
+        />
+        <input
+          type="text"
+          value={allergens}
+          onChange={e => setAllergens(e.target.value)}
+          placeholder="Allergene, kommasepariert"
           className="w-full border p-2 rounded"
         />
         <input type="file" onChange={e => setImage(e.target.files[0])} className="w-full" />

--- a/components/InfoModal.js
+++ b/components/InfoModal.js
@@ -1,0 +1,29 @@
+'use client';
+export default function InfoModal({ meal, isOpen, onClose }) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-20">
+      <div className="bg-white rounded-lg p-6 w-80 space-y-4">
+        <h3 className="text-lg font-semibold">{meal.title}</h3>
+        {meal.ingredients && (
+          <p className="text-sm text-gray-700">
+            <span className="font-medium text-gray-800">Zutaten:</span>{' '}
+            {meal.ingredients}
+          </p>
+        )}
+        {meal.allergens && (
+          <p className="text-sm text-gray-700">
+            <span className="font-medium text-gray-800">Allergene:</span>{' '}
+            {meal.allergens}
+          </p>
+        )}
+        <div className="flex justify-end">
+          <button onClick={onClose} className="px-4 py-2 rounded bg-primary text-white">
+            Schliessen
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/schema.sql
+++ b/schema.sql
@@ -26,6 +26,8 @@ CREATE TABLE IF NOT EXISTS `menus` (
   `image` VARCHAR(255) NOT NULL,
   `student_price` DECIMAL(5,2) NOT NULL,
   `teacher_price` DECIMAL(5,2) NOT NULL,
+  `ingredients` TEXT NOT NULL,
+  `allergens` VARCHAR(255) NOT NULL,
   `day` ENUM('montag','dienstag','mittwoch','donnerstag','freitag') NOT NULL,
   `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
@@ -34,23 +36,23 @@ CREATE TABLE IF NOT EXISTS `menus` (
 -- Seed default menus so they can be managed like normal entries
 TRUNCATE TABLE menus;
 
-INSERT INTO `menus` (`title`, `image`, `student_price`, `teacher_price`, `day`) VALUES
-('Hähnchen-Gemüsepfanne mit Reis', '/reis_haehnchen_pfanne_2.jpg', 8.90, 10.90, 'montag'),
-('Spaghetti mit Hackfleisch-Tomatensauce', '/202_spaghetti-bolognese.jpg', 7.90, 9.90, 'montag'),
-('Gemüse-Lasagne mit Spinat und Ricotta', '/Download.jpg', 7.50, 9.50, 'montag'),
+INSERT INTO `menus` (`title`, `image`, `student_price`, `teacher_price`, `day`, `ingredients`, `allergens`) VALUES
+('Hähnchen-Gemüsepfanne mit Reis', '/reis_haehnchen_pfanne_2.jpg', 8.90, 10.90, 'montag', 'Hähnchen,Gemüse,Reis', 'A'),
+('Spaghetti mit Hackfleisch-Tomatensauce', '/202_spaghetti-bolognese.jpg', 7.90, 9.90, 'montag', 'Spaghetti,Hackfleisch,Tomaten', 'A'),
+('Gemüse-Lasagne mit Spinat und Ricotta', '/Download.jpg', 7.50, 9.50, 'montag', 'Nudelblätter,Spinat,Ricotta', 'A,L'),
 
-('Rindergeschnetzeltes mit Reis', '/Geschnetzeltes-mit-Reis.jpg', 9.80, 11.80, 'dienstag'),
-('Penne Arrabiata', '/Penne-arrabbiata.jpg', 6.90, 8.90, 'dienstag'),
-('Gemüse-Curry', '/Gemüse-Curry.jpg', 7.20, 9.20, 'dienstag'),
+('Rindergeschnetzeltes mit Reis', '/Geschnetzeltes-mit-Reis.jpg', 9.80, 11.80, 'dienstag', 'Rindfleisch,Reis,Gemüse', 'A'),
+('Penne Arrabiata', '/Penne-arrabbiata.jpg', 6.90, 8.90, 'dienstag', 'Penne,Tomaten,Chili', 'A'),
+('Gemüse-Curry', '/Gemüse-Curry.jpg', 7.20, 9.20, 'dienstag', 'Gemüse,Kokosmilch,Curry', ''),
 
-('Fischstäbchen mit Kartoffelsalat', '/Fischstäbchen-mit-Kartoffelsalat.jpg', 8.50, 10.50, 'mittwoch'),
-('Käsespätzle', '/Käsespätzle.jpg', 6.80, 8.80, 'mittwoch'),
-('Tomaten-Mozzarella-Auflauf', '/Tomaten-Mozzarella-Auflauf.jpg', 7.00, 9.00, 'mittwoch'),
+('Fischstäbchen mit Kartoffelsalat', '/Fischstäbchen-mit-Kartoffelsalat.jpg', 8.50, 10.50, 'mittwoch', 'Fischstäbchen,Kartoffeln,Remoulade', 'A'),
+('Käsespätzle', '/Käsespätzle.jpg', 6.80, 8.80, 'mittwoch', 'Spätzle,Käse,Zwiebeln', 'A,L'),
+('Tomaten-Mozzarella-Auflauf', '/Tomaten-Mozzarella-Auflauf.jpg', 7.00, 9.00, 'mittwoch', 'Tomaten,Mozzarella,Basilikum', 'L'),
 
-('Schweinebraten mit Knödel', '/Schweinebraten-mit-Knödel.jpg', 9.90, 11.90, 'donnerstag'),
-('Nudelauflauf', '/Nudelauflauf.jpg', 7.00, 9.00, 'donnerstag'),
-('Grüne Bohnen Eintopf', '/Grüne-Bohnen-Eintopf.jpg', 6.50, 8.50, 'donnerstag'),
+('Schweinebraten mit Knödel', '/Schweinebraten-mit-Knödel.jpg', 9.90, 11.90, 'donnerstag', 'Schweinebraten,Knödel,Sauce', 'A'),
+('Nudelauflauf', '/Nudelauflauf.jpg', 7.00, 9.00, 'donnerstag', 'Nudeln,Käse,Sahne', 'A,L'),
+('Grüne Bohnen Eintopf', '/Grüne-Bohnen-Eintopf.jpg', 6.50, 8.50, 'donnerstag', 'Bohnen,Kartoffeln,Speck', ''),
 
-('Currywurst mit Pommes', '/Currywurst-Pommes.jpg', 7.90, 9.90, 'freitag'),
-('Pizza Margherita', '/PizzaMargherita.jpg', 6.90, 8.90, 'freitag'),
-('Linsensuppe', '/Linsensuppe.jpg', 5.90, 7.90, 'freitag');
+('Currywurst mit Pommes', '/Currywurst-Pommes.jpg', 7.90, 9.90, 'freitag', 'Currywurst,Pommes,Currysauce', 'A'),
+('Pizza Margherita', '/PizzaMargherita.jpg', 6.90, 8.90, 'freitag', 'Pizzateig,Tomaten,Käse', 'A,L'),
+('Linsensuppe', '/Linsensuppe.jpg', 5.90, 7.90, 'freitag', 'Linsen,Gemüse,Brühe', '');


### PR DESCRIPTION
## Summary
- extend `menus` table with `ingredients` and `allergens`
- seed example menus with ingredients/allergens
- accept new fields in menu API routes
- show info icon for each meal
- add info modal to display dish details
- include ingredients/allergen inputs in admin form

## Testing
- `npx next lint` *(fails: Need to install packages)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685271498e1c832583048397e3593d8b